### PR TITLE
Upgrade to ES6

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
  * Marker.io - https://marker.io
  * Browser loader for the Marker.io SDK
  */
-module.exports = {
+export default {
   loadWidget(params) {
     // Warn if unknown params are provided
     const knownParams = ['destination', 'reporter', 'customShimUrl', 'customData'];


### PR DESCRIPTION
This small change allows this package to be dynamically loaded via the ES6 dynamic import statement.

At present, with it only available as CommonJS, I need to be using a bundler to use this package. My project is too small to need a bundler, and I don't want to set one up just for this tiny package.