### PR TITLE
Typescript rewrite using typings from @bramski + Better compatibility with ESM & CommonJS

### DIFF
--- a/configs/tsconfig.base.json
+++ b/configs/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "checkJs": true,
+    "allowJs": true,
+    "declaration": true,
+    "declarationMap": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "files": ["../src/index.ts"]
+}

--- a/configs/tsconfig.cjs.json
+++ b/configs/tsconfig.cjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2016", "DOM"],
+    "target": "ES6",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "../lib/cjs",
+    "declarationDir": "../lib/cjs/types"
+  }
+}

--- a/configs/tsconfig.esm.json
+++ b/configs/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "../lib/esm",
+    "declarationDir": "../lib/esm/types"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "@marker.io/browser",
+  "version": "0.13.0-beta.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@marker.io/browser",
+      "version": "0.13.0-beta.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^4.8.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
+  "dependencies": {
+    "typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,15 @@
 {
   "name": "@marker.io/browser",
-  "version": "0.12.0",
+  "version": "0.13.0-beta.0",
   "description": "Marker.io browser SDK",
+  "keywords": [
+    "bug reporting",
+    "feedback widget",
+    "markerio"
+  ],
+  "author": "Marker.io",
+  "license": "MIT",
+  "homepage": "https://github.com/marker-io/browser#readme",
   "projectMeta": {
     "provider": {
       "name": "Marker.io",
@@ -11,22 +19,38 @@
       "browser": "./src/index.js"
     }
   },
-  "keywords": [
-    "bug reporting",
-    "feedback widget",
-    "markerio"
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./lib/esm/types/index.d.ts",
+        "default": "./lib/esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/cjs/types/index.d.ts",
+        "default": "./lib/cjs/index.js"
+      }
+    }
+  },
+  "main": "./lib/cjs/index.js",
+  "types": "./lib/cjs/types/index.d.ts",
+  "files": [
+    "lib/**/*"
   ],
-  "main": "src/index.js",
   "scripts": {
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
-    "release:major": "npm version major && npm publish"
+    "release:major": "npm version major && npm publish",
+    "clean": "rm -rf ./lib",
+    "build": "npm run clean && npm run build:esm && npm run build:cjs",
+    "build:esm": "tsc -p ./configs/tsconfig.esm.json && mv lib/esm/index.js lib/esm/index.mjs",
+    "build:cjs": "tsc -p ./configs/tsconfig.cjs.json",
+    "prepack": "npm run build"
   },
-  "author": "Marker.io",
-  "license": "MIT",
-  "homepage": "https://github.com/marker-io/browser#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/marker-io/browser-sdk"
+  },
+  "devDependencies": {
+    "typescript": "^4.8.4"
   }
 }


### PR DESCRIPTION
Includes typings based on @bramski's suggestion in https://github.com/marker-io/browser-sdk/pull/14 and also implements changes to improve importability of the package with ESM vs CommonJS