### PR TITLE
fix: export MarkerEventName type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export type MarkerReporter = {
   fullName: string;
 };
 
-type MarkerEventName =
+export type MarkerEventName =
   | 'load'
   | 'loaderror'
   | 'beforeunload'


### PR DESCRIPTION
Make MarkerEventName type accessible to consumer

<img width="709" alt="image" src="https://github.com/marker-io/browser-sdk/assets/45228014/b57bae87-6210-4995-89e7-88c2bfb71df8">

@olivierkaisin 